### PR TITLE
Fixing issue when params are not passed

### DIFF
--- a/src/CliRequest.php
+++ b/src/CliRequest.php
@@ -57,13 +57,13 @@ class CliRequest
      */
     private function getUri($path, $params)
     {
-        $uri = '';
-        if (strlen($path) === 0) {
-            $path = '/';
+        $uri = '/';
+        if (strlen($path) > 0) {
+            $uri = $path;
         }
 
-        if (strlen($params) !== 0) {
-            $uri = $path . '?' . $params;
+        if (strlen($params) > 0) {
+            $uri .= '?' . $params;
         }
 
         return $uri;

--- a/tests/phpunit/CliRequestTest.php
+++ b/tests/phpunit/CliRequestTest.php
@@ -109,4 +109,23 @@ class CliRequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($req, $cliRequest->getRequest());
     }
+
+    public function testRequestWhenNoParamsArePassed()
+    {
+        unset($GLOBALS['argv'][3]);
+
+        $req = $this->requestFactory();
+        $res = new Response();
+        $next = function (Request $req, Response $res) {
+            return $res;
+        };
+
+        /** @var CliRequest $cliRequest */
+        $cliRequest = new CliRequest();
+
+        /** @var  ResponseInterface $res */
+        $res = $cliRequest($req, $res, $next);
+
+        $this->assertEquals('/status', $cliRequest->getRequest()->getUri()->getPath());
+    }
 }


### PR DESCRIPTION
There was an issue, when passing argv 0,1,2, but not 3, then the path would return '/' rather than '/status'.

Cheers
