### PR TITLE
Turn HTTPS On For Mock Request

### DIFF
--- a/src/CliRequest.php
+++ b/src/CliRequest.php
@@ -96,6 +96,7 @@ class CliRequest
             if (strtoupper($method) === 'GET') {
                 $this->request = \Slim\Http\Request::createFromEnvironment(\Slim\Http\Environment::mock([
                     'REQUEST_METHOD'    => 'GET',
+                    'HTTPS'             => 'on'
                     'REQUEST_URI'       => $this->getUri($path, $params),
                     'QUERY_STRING'      => $params
                 ]));


### PR DESCRIPTION
It's common to use middleware to check that HTTPS is being used. Tweak the defaults to the MOCK to fake HTTPS via CLI